### PR TITLE
Adjust tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
             matrix:
                 php: [8.1, 8.0, 7.4, 7.3]
                 laravel: [8.*, 9.*]
-                dependency-version: [prefer-lowest, prefer-stable]
+                stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,10 @@ jobs:
 
         strategy:
             matrix:
-                php: [7.4, 7.3, 7.2]
-                laravel: [7.*, ^6.10]
+                php: [8.1, 8.0, 7.4, 7.3]
+                laravel: [8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
-                include:
-                    - laravel: 7.*
-                      testbench: 5.*
-                    - laravel: ^6.10
-                      testbench: ^4.4
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -29,15 +24,20 @@ jobs:
               uses: actions/checkout@v1
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v1
+              uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
                   coverage: none
 
+
             - name: Install dependencies
-              run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.additional-deps }} --no-interaction --no-update
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+              uses: nick-invision/retry@v2
+              with:
+                  timeout_minutes: 5
+                  max_attempts: 5
+                  command: |
+                      composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
+                      composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
         exclude:
           - laravel: 9.*
-          php: 7.4
+            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-        php-version: ${{ matrix.php }}
-        coverage: none
+          php-version: ${{ matrix.php }}
+          coverage: none
 
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.0, 7.4]
+        php: [8.1, 8.0, 7.4, 7.3]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:
           - laravel: 9.*
             php: 7.4
+        exclude:
+          - laravel: 9.*
+            php: 7.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [8.1, 8.0, 7.4]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,43 +4,43 @@ on:
   push:
   pull_request:
   schedule:
-      - cron: '0 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
-    php-tests:
-        runs-on: ${{ matrix.os }}
+  php-tests:
+    runs-on: ${{ matrix.os }}
 
-        strategy:
-            matrix:
-                php: [8.1, 8.0, 7.4, 7.3]
-                laravel: [8.*, 9.*]
-                stability: [prefer-lowest, prefer-stable]
-                os: [ubuntu-latest]
-                exclude:
-                    - laravel: 9.*
-                      php: 7.4
+    strategy:
+      matrix:
+        php: [8.1, 8.0, 7.4, 7.3]
+        laravel: [8.*, 9.*]
+        stability: [prefer-lowest, prefer-stable]
+        os: [ubuntu-latest]
+        exclude:
+          - laravel: 9.*
+          php: 7.4
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  coverage: none
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+        php-version: ${{ matrix.php }}
+        coverage: none
 
 
-            - name: Install dependencies
-              uses: nick-invision/retry@v2
-              with:
-                  timeout_minutes: 5
-                  max_attempts: 5
-                  command: |
-                      composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
-                      composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+      - name: Install dependencies
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: |
+            composer require "illuminate/contracts:${{ matrix.laravel }}" --dev --no-interaction --no-update
+            composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
-            - name: Execute tests
-              run: vendor/bin/phpunit
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
         exclude:
           - laravel: 9.*
             php: 7.4
-        exclude:
           - laravel: 9.*
             php: 7.3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
                 laravel: [8.*, 9.*]
                 stability: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest]
+                exclude:
+                    - laravel: 9.*
+                      php: 7.4
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel/framework": "^6.10 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0"
+        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Debug Laravel views",
     "license": "MIT",
     "require": {
-        "laravel/framework": "^6.10 || ^7.0 || ^8.0 || ^9.0"
+        "laravel/framework": "^8.0 || ^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0"
+        "orchestra/testbench": "^6.18 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "laravel/framework": "^8.0 || ^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.18 || ^7.0"
+        "orchestra/testbench": "^6.22 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Drop Laravel 6 and 7
- Test Laravel 8 and 9
- Test PHP 8.0 and 8.1
- Adjust workflow to require illuminate/contracts so dependencies are installed appropriately
- Use 2 spaces for tabs in test workflow file